### PR TITLE
Edit key form: Fix retaining of readonly values on validation errors.

### DIFF
--- a/ftw/tokenauth/service_keys/browser/edit.py
+++ b/ftw/tokenauth/service_keys/browser/edit.py
@@ -23,11 +23,18 @@ class EditKeyForm(BaseForm):
     def updateWidgets(self, *args, **kwargs):
         super(EditKeyForm, self).updateWidgets(*args, **kwargs)
 
-        # Hack to retain widget values on validation error
-        if 'form.buttons.save' not in self.request:
-            # Prefill form
-            key = self.get_key()
-            for widget in self.widgets.values():
+        saving = 'form.buttons.save' in self.request
+
+        # Prefill form widgets with persisted values from DB
+        key = self.get_key()
+        for widget in self.widgets.values():
+            # Always prefill readonly widgets.
+            #
+            # Prefill other widgets only upon initial rendering of the form,
+            # not when trying to save - this is so we don't override
+            # actual user provided inputs with persisted values from the
+            # DB when rendering the form in the case of validation errors.
+            if widget.field.readonly or not saving:
                 name = widget.field.getName()
                 value = key[name]
                 converter = IDataConverter(widget)

--- a/ftw/tokenauth/tests/test_manage_service_keys.py
+++ b/ftw/tokenauth/tests/test_manage_service_keys.py
@@ -283,9 +283,10 @@ class TestEditServiceKeysView(FunctionalTestCase):
 
     @browsing
     def test_edit_key_form_retains_widget_values_on_error(self, browser):
-        create(Builder('service_key')
-               .having(title='Some key',
-                       ip_range='192.168.0.0/16'))
+        with freeze(datetime(2018, 1, 7, 15, 30)):
+            service_key = create(Builder('service_key')
+                                 .having(title='Some key',
+                                         ip_range='192.168.0.0/16'))
         transaction.commit()
 
         browser.login().open(view='@@manage-service-keys')
@@ -313,6 +314,12 @@ class TestEditServiceKeysView(FunctionalTestCase):
              ('form.buttons.cancel', 'Cancel'),
              ('form.buttons.save', 'Save')],
             form.values.items())
+
+        # Assert that readonly widget values are retained as well
+        widget_values = form.css('div.field').text
+        self.assertIn('User ID %s' % TEST_USER_ID, widget_values)
+        self.assertIn('Key ID %s' % service_key['key_id'], widget_values)
+        self.assertIn('Issued 1/7/18 3:30 PM', widget_values)
 
     @browsing
     def test_edit_key_form_handles_no_changes_being_made(self, browser):


### PR DESCRIPTION
This fixes an issue where on **validation errors** in the edit key form, values of **readonly fields** were not retained / prefilled.