### PR TITLE
Support multiple addresses/networks in IP range specifications.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,9 @@ They need to issue a service key that is then displayed **exactly once** for
 download, and store the private key in a safe location accessible to the
 client that will use it.
 
-TODO: Document IP range restrictions and key revocation.
+`IP range restrictions`_ may also be defined when issuing a key.
+
+TODO: Document Key revocation.
 
 2. Create and sign JWT authorization grant using service key
 ------------------------------------------------------------
@@ -203,6 +205,37 @@ Python Example:
 
 TODO: Document error responses for invalid tokens
 
+
+Advanced use
+============
+
+This section covers some more advanced settings and functionality of
+``ftw.tokenauth``.
+
+IP range restrictions
+---------------------
+
+When issuing a key, IP range restrictions may be defined that limit from what
+source IP address access tokens tied to this key may be used.
+
+Changes to IP range restrictions for a given key are effective immediately,
+and also affect already issued tokens tied to this key.
+
+IP ranges may be specified as a single IP address or as a network in
+`CIDR notation <https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation>`_
+using the slash-suffix.
+
+Multiple ranges may be provided in comma-separated form.
+
+Examples of valid IP range specifications:
+
+- ``192.168.1.1``
+- ``192.168.0.0/16``
+- ``192.168.1.1, 10.0.0.0/8``
+
+Authentication attempts from an unauthorized source IP address are logged
+server side, but not indicated to the client in any particular way -
+authentication is simply not performed.
 
 Links
 =====

--- a/ftw/tokenauth/locales/de/LC_MESSAGES/ftw.tokenauth.po
+++ b/ftw/tokenauth/locales/de/LC_MESSAGES/ftw.tokenauth.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-03-11 14:40+0000\n"
+"POT-Creation-Date: 2018-03-11 18:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -12,14 +12,15 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 
 #: ./ftw/tokenauth/service_keys/browser/base_form.py:49
-msgid "Allowed IP range specification in <strong><a href=\"https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation\">CIDR notation</a></strong>."
-msgstr "Erlaubter IP-Range in <strong><a href=\"https://de.wikipedia.org/wiki/Classless_Inter-Domain_Routing#Beispiele\">CIDR notation</a></strong>."
+msgid "Allowed IP range specification in <strong><a href=\"https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation\">CIDR notation</a></strong>. Multiple comma-separated addresses / networks may be supplied."
+msgstr "Erlaubter IP-Range in <strong><a href=\"https://de.wikipedia.org/wiki/Classless_Inter-Domain_Routing#Beispiele\">CIDR notation</a></strong>. Mehrere Adressen / Netzwerke können kommagetrennt angegeben werden."
 
 #: ./ftw/tokenauth/service_keys/browser/download_key.pt:49
+#: ./ftw/tokenauth/service_keys/browser/view_usage_logs.pt:55
 msgid "Back to [Manage Service Keys]"
 msgstr "Zurück zu [Service-Schlüssel verwalten]"
 
-#: ./ftw/tokenauth/service_keys/browser/edit.py:90
+#: ./ftw/tokenauth/service_keys/browser/edit.py:97
 #: ./ftw/tokenauth/service_keys/browser/issue.py:59
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -44,7 +45,7 @@ msgstr "Bearbeiten"
 msgid "Edit Service Key"
 msgstr "Service-Schlüssel bearbeiten"
 
-#: ./ftw/tokenauth/service_keys/browser/edit.py:92
+#: ./ftw/tokenauth/service_keys/browser/edit.py:99
 msgid "Edit cancelled"
 msgstr "Bearbeiten abgebrochen"
 
@@ -105,7 +106,7 @@ msgstr "Service-Schlüssel verwalten"
 msgid "Recent uses of this key"
 msgstr "Kürzliche Verwendungen dieses Schlüssels"
 
-#: ./ftw/tokenauth/service_keys/browser/edit.py:77
+#: ./ftw/tokenauth/service_keys/browser/edit.py:84
 msgid "Save"
 msgstr "Speichern"
 

--- a/ftw/tokenauth/locales/ftw.tokenauth.pot
+++ b/ftw/tokenauth/locales/ftw.tokenauth.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-03-11 14:40+0000\n"
+"POT-Creation-Date: 2018-03-11 18:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,14 +15,15 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 
 #: ./ftw/tokenauth/service_keys/browser/base_form.py:49
-msgid "Allowed IP range specification in <strong><a href=\"https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation\">CIDR notation</a></strong>."
+msgid "Allowed IP range specification in <strong><a href=\"https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation\">CIDR notation</a></strong>. Multiple comma-separated addresses / networks may be supplied."
 msgstr ""
 
 #: ./ftw/tokenauth/service_keys/browser/download_key.pt:49
+#: ./ftw/tokenauth/service_keys/browser/view_usage_logs.pt:55
 msgid "Back to [Manage Service Keys]"
 msgstr ""
 
-#: ./ftw/tokenauth/service_keys/browser/edit.py:90
+#: ./ftw/tokenauth/service_keys/browser/edit.py:97
 #: ./ftw/tokenauth/service_keys/browser/issue.py:59
 msgid "Cancel"
 msgstr ""
@@ -47,7 +48,7 @@ msgstr ""
 msgid "Edit Service Key"
 msgstr ""
 
-#: ./ftw/tokenauth/service_keys/browser/edit.py:92
+#: ./ftw/tokenauth/service_keys/browser/edit.py:99
 msgid "Edit cancelled"
 msgstr ""
 
@@ -108,7 +109,7 @@ msgstr ""
 msgid "Recent uses of this key"
 msgstr ""
 
-#: ./ftw/tokenauth/service_keys/browser/edit.py:77
+#: ./ftw/tokenauth/service_keys/browser/edit.py:84
 msgid "Save"
 msgstr ""
 

--- a/ftw/tokenauth/pas/ip_range.py
+++ b/ftw/tokenauth/pas/ip_range.py
@@ -3,23 +3,42 @@ from ipaddress import ip_network
 
 
 class InvalidIPRangeSpecification(ValueError):
-    """
+    """Error in specification of allowed IP range.
     """
 
 
 def parse_ip_range(ip_range):
-    try:
-        network = ip_network(ip_range)
-    except ValueError as exc:
-        raise InvalidIPRangeSpecification(exc.message)
-    return network
+    """Parse an IP range specification and return a list of allowed networks.
+
+    IP ranges may be specified as a single IP address or as a network in CIDR
+    notation using the slash-suffix.
+
+    Multiple ranges may be provided in comma-separated form.
+
+    Examples:
+
+    192.168.1.1
+    192.168.0.0/16
+    192.168.1.1, 10.0.0.0/8
+    """
+    ranges = [rng.strip() for rng in ip_range.split(',')]
+    networks = []
+    for rng in ranges:
+        try:
+            network = ip_network(rng)
+        except ValueError as exc:
+            raise InvalidIPRangeSpecification(exc.message)
+        networks.append(network)
+    return networks
 
 
 def permitted_ip(client_ip, ip_range):
+    """Return True if a client IP is in the given range(s), False otherwise.
+    """
     try:
         allowed_networks = parse_ip_range(ip_range)
     except InvalidIPRangeSpecification:
-        # TODO: Maybe log this? Might help in debugging
-        return None
+        return False
 
-    return ip_address(client_ip) in allowed_networks
+    ip = ip_address(client_ip)
+    return any(ip in net for net in allowed_networks)

--- a/ftw/tokenauth/service_keys/browser/base_form.py
+++ b/ftw/tokenauth/service_keys/browser/base_form.py
@@ -49,7 +49,8 @@ class IKeyMetadataSchema(model.Schema):
         description=_(
             u'Allowed IP range specification in '
             u'<strong><a href="https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation">'  # noqa
-            u'CIDR notation</a></strong>.'),
+            u'CIDR notation</a></strong>. '
+            u'Multiple comma-separated addresses / networks may be supplied.'),
     )
 
 

--- a/ftw/tokenauth/tests/test_ip_range_validation.py
+++ b/ftw/tokenauth/tests/test_ip_range_validation.py
@@ -1,16 +1,113 @@
+from ftw.tokenauth.pas.ip_range import InvalidIPRangeSpecification
+from ftw.tokenauth.pas.ip_range import parse_ip_range
+from ftw.tokenauth.pas.ip_range import permitted_ip
 from ftw.tokenauth.service_keys.browser.base_form import valid_ip_range
+from ipaddress import ip_network
 from zope.interface import Invalid
 import unittest
+
+
+class TestIPRangeParsing(unittest.TestCase):
+
+    def test_single_ipv4_address_is_parsed(self):
+        self.assertEqual(
+            [ip_network('192.168.0.1')],
+            parse_ip_range('192.168.0.1'))
+
+    def test_single_ipv4_cidr_network_is_parsed(self):
+        self.assertEqual(
+            [ip_network('192.168.0.0/16')],
+            parse_ip_range('192.168.0.0/16'))
+
+        self.assertTrue(valid_ip_range('192.168.0.0/16'))
+
+    def test_invalid_ip_address_raises_exception(self):
+        with self.assertRaises(InvalidIPRangeSpecification):
+            parse_ip_range('500.500.0.0')
+
+    def test_multiple_ipv4_addresses_are_parsed(self):
+        self.assertEqual(
+            [ip_network('10.0.0.1'), ip_network('192.168.0.1')],
+            parse_ip_range('10.0.0.1,192.168.0.1'))
+
+    def test_mix_of_single_adress_and_networks_is_parsed(self):
+        self.assertEqual(
+            [ip_network('10.1.1.5'), ip_network('192.168.0.0/16')],
+            parse_ip_range('10.1.1.5,192.168.0.0/16'))
+
+    def test_white_space_is_stripped(self):
+        self.assertEqual(
+            [ip_network('10.0.0.1'), ip_network('192.168.0.1')],
+            parse_ip_range('10.0.0.1  ,  192.168.0.1'))
+
+
+class TestPermittedIPChecking(unittest.TestCase):
+
+    def test_allowed_ip_in_single_ipv4_address_range(self):
+        self.assertTrue(
+            permitted_ip('192.168.0.1', '192.168.0.1')
+        )
+
+    def test_disallowed_ip_in_single_ipv4_address_range(self):
+        self.assertFalse(
+            permitted_ip('10.0.0.0', '192.168.0.1')
+        )
+
+    def test_allowed_ip_in_single_ipv4_cidr_network_range(self):
+        self.assertTrue(
+            permitted_ip('192.168.0.1', '192.168.0.0/16')
+        )
+
+    def test_disallowed_ip_in_single_ipv4_cidr_network_range(self):
+        self.assertFalse(
+            permitted_ip('10.0.0.0', '192.168.0.0/16')
+        )
+
+    def test_invalid_ip_address_is_rejected(self):
+        with self.assertRaises(ValueError):
+            permitted_ip('500.500.0.0', '192.168.0.0/16')
+
+    def test_invalid_ip_range_is_rejected(self):
+        self.assertFalse(
+            permitted_ip('10.0.0.1', '500.500.0.0/33')
+        )
+
+    def test_allowed_ip_in_multiple_ipv4_address_ranges(self):
+        self.assertTrue(
+            permitted_ip('10.0.0.5', '10.0.0.5, 192.168.0.1')
+        )
+        self.assertTrue(
+            permitted_ip('192.168.0.1', '10.0.0.5, 192.168.0.1')
+        )
+
+    def test_disallowed_ip_in_multiple_ipv4_address_ranges(self):
+        self.assertFalse(
+            permitted_ip('192.168.0.7', '10.0.0.5, 192.168.0.1')
+        )
+
+    def test_allowed_ip_in_multiple_ipv4_cidr_network_ranges(self):
+        self.assertTrue(
+            permitted_ip('192.168.5.5', '10.0.0.0/8, 192.168.0.0/16')
+        )
+        self.assertTrue(
+            permitted_ip('10.1.5.20', '10.0.0.0/8, 192.168.0.0/16')
+        )
 
 
 class TestIPRangeFormValidator(unittest.TestCase):
 
     def test_single_ipv4_address_is_valid(self):
-        self.assertTrue(valid_ip_range('192.168.0.0'))
+        self.assertTrue(valid_ip_range('192.168.0.1'))
 
     def test_single_ipv4_cidr_network_is_valid(self):
         self.assertTrue(valid_ip_range('192.168.0.0/16'))
 
-    def test_invalid_ip_address_is_rejected(self):
+    def test_invalid_ip_range_is_rejected(self):
         with self.assertRaises(Invalid):
-            valid_ip_range('500.500.0.0')
+            valid_ip_range('500.500.0.0/33')
+
+    def test_multiple_ipv4_addresses_are_valid(self):
+        self.assertTrue(valid_ip_range('10.0.0.1, 192.168.0.1'))
+
+    def test_multiple_ipv4_cidr_networks_are_valid(self):
+        self.assertTrue(valid_ip_range('10.0.0.0/8, 192.168.0.0/16'))

--- a/ftw/tokenauth/tests/test_manage_service_keys.py
+++ b/ftw/tokenauth/tests/test_manage_service_keys.py
@@ -150,7 +150,8 @@ class TestManageServiceKeysView(FunctionalTestCase):
         self.assertEqual(['There were some errors.'], error_messages())
 
         self.assertEqual(
-            {'IP Range Allowed IP range specification in CIDR notation.':
+            {'IP Range Allowed IP range specification in CIDR notation. '
+             'Multiple comma-separated addresses / networks may be supplied.':
                 ['Invalid IP range: 192.168.5.5/16 has host bits set']},
             erroneous_fields(browser.forms['form']))
 
@@ -266,7 +267,8 @@ class TestEditServiceKeysView(FunctionalTestCase):
         self.assertEqual(['There were some errors.'], error_messages())
 
         self.assertEqual(
-            {'IP Range Allowed IP range specification in CIDR notation.':
+            {'IP Range Allowed IP range specification in CIDR notation. '
+             'Multiple comma-separated addresses / networks may be supplied.':
                 ['Invalid IP range: 10.0.5.5/24 has host bits set'],
              'Title':
                 ['Required input is missing.']},
@@ -301,7 +303,8 @@ class TestEditServiceKeysView(FunctionalTestCase):
         self.assertEqual(['There were some errors.'], error_messages())
 
         self.assertEqual(
-            {'IP Range Allowed IP range specification in CIDR notation.':
+            {'IP Range Allowed IP range specification in CIDR notation. '
+             'Multiple comma-separated addresses / networks may be supplied.':
                 ['Invalid IP range: 10.0.5.5/24 has host bits set'],
              'Title':
                 ['Required input is missing.']},


### PR DESCRIPTION
Support **multiple addresses/networks** in IP range specifications for service keys.

Examples of valid specifications:

- `192.168.1.1`
- `192.168.0.0/16`
- `192.168.1.1, 10.0.0.0/8`
