### PR TITLE
If lawgiver is installed, ignore "ftw.tokenauth: Manage own Service Keys" permission.

### DIFF
--- a/ftw/tokenauth/configure.zcml
+++ b/ftw/tokenauth/configure.zcml
@@ -2,6 +2,7 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:five="http://namespaces.zope.org/five"
     xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:profilehook="http://namespaces.zope.org/profilehook"
     i18n_domain="ftw.tokenauth">
@@ -9,6 +10,7 @@
   <five:registerPackage package="." initialize=".initialize" />
 
   <include file="permissions.zcml" />
+  <include file="lawgiver.zcml" zcml:condition="installed ftw.lawgiver" />
 
   <i18n:registerTranslations directory="locales" />
 

--- a/ftw/tokenauth/lawgiver.zcml
+++ b/ftw/tokenauth/lawgiver.zcml
@@ -1,0 +1,12 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:lawgiver="http://namespaces.zope.org/lawgiver"
+    i18n_domain="ftw.lawgiver">
+
+    <include package="ftw.lawgiver" file="meta.zcml" />
+
+    <lawgiver:ignore
+        permissions="ftw.tokenauth: Manage own Service Keys"
+        />
+
+</configure>


### PR DESCRIPTION
If lawgiver is installed, ignore the `ftw.tokenauth: Manage own Service Keys` permission.

It hardly makes any sense for this permission to be managed through a workflow.