### PR TITLE
Switch to ipaddress module instead of py2-ipaddress for IP range parsing

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Switch to `ipaddress` module instead of `py2-ipaddress` for IP range
+  parsing, and fix unicode handling.
+  [lgraf]
 
 
 1.0.0 (2018-04-04)

--- a/ftw/tokenauth/pas/ip_range.py
+++ b/ftw/tokenauth/pas/ip_range.py
@@ -21,7 +21,7 @@ def parse_ip_range(ip_range):
     192.168.0.0/16
     192.168.1.1, 10.0.0.0/8
     """
-    ranges = [rng.strip() for rng in ip_range.split(',')]
+    ranges = [rng.strip() for rng in to_unicode(ip_range).split(u',')]
     networks = []
     for rng in ranges:
         try:
@@ -40,5 +40,18 @@ def permitted_ip(client_ip, ip_range):
     except InvalidIPRangeSpecification:
         return False
 
-    ip = ip_address(client_ip)
+    ip = ip_address(to_unicode(client_ip))
     return any(ip in net for net in allowed_networks)
+
+
+def to_unicode(ip_spec):
+    """Ensure ip_spec is unicode, decoding it if necessary.
+
+    The `ipaddress` module (as opposed to `py2-ipaddress`) absolutely
+    requires IP specifications to be passed in as unicode. We therefore make
+    sure the ip_spec is unicode, decoding it as ASCII if necessary (IP specs
+    should never contain any non-ASCII characters).
+    """
+    if not isinstance(ip_spec, unicode):
+        ip_spec = ip_spec.decode('ascii')
+    return ip_spec

--- a/ftw/tokenauth/tests/test_ip_range_validation.py
+++ b/ftw/tokenauth/tests/test_ip_range_validation.py
@@ -11,12 +11,12 @@ class TestIPRangeParsing(unittest.TestCase):
 
     def test_single_ipv4_address_is_parsed(self):
         self.assertEqual(
-            [ip_network('192.168.0.1')],
+            [ip_network(u'192.168.0.1')],
             parse_ip_range('192.168.0.1'))
 
     def test_single_ipv4_cidr_network_is_parsed(self):
         self.assertEqual(
-            [ip_network('192.168.0.0/16')],
+            [ip_network(u'192.168.0.0/16')],
             parse_ip_range('192.168.0.0/16'))
 
         self.assertTrue(valid_ip_range('192.168.0.0/16'))
@@ -27,17 +27,17 @@ class TestIPRangeParsing(unittest.TestCase):
 
     def test_multiple_ipv4_addresses_are_parsed(self):
         self.assertEqual(
-            [ip_network('10.0.0.1'), ip_network('192.168.0.1')],
+            [ip_network(u'10.0.0.1'), ip_network(u'192.168.0.1')],
             parse_ip_range('10.0.0.1,192.168.0.1'))
 
     def test_mix_of_single_adress_and_networks_is_parsed(self):
         self.assertEqual(
-            [ip_network('10.1.1.5'), ip_network('192.168.0.0/16')],
+            [ip_network(u'10.1.1.5'), ip_network(u'192.168.0.0/16')],
             parse_ip_range('10.1.1.5,192.168.0.0/16'))
 
     def test_white_space_is_stripped(self):
         self.assertEqual(
-            [ip_network('10.0.0.1'), ip_network('192.168.0.1')],
+            [ip_network(u'10.0.0.1'), ip_network(u'192.168.0.1')],
             parse_ip_range('10.0.0.1  ,  192.168.0.1'))
 
 

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(name='ftw.tokenauth',
           # Other dependencies
           'cryptography',
           'ftw.profilehook',
-          'py2-ipaddress',
+          'ipaddress',
           'PyJWT',
       ],
       tests_require=tests_require,


### PR DESCRIPTION
Switch to `ipaddress` module instead of `py2-ipaddress` for IP range parsing, and fix unicode handling:

We previously included both the `py2-ipaddress` and `ipaddress` packages as dependencies, `py2-ipaddress` directly from `ftw.tokenauth`, and `ipaddress` as an indirect dependency of the `cryptography` module.

Because they both occupy the same module namespace, any one of them was picked at random, depending on module load order. Because the `ipaddress` module absolutely requires IP specifications to be passed in as unicode, this lead to sporadic failures.

Since the `ipaddress` module is already an (indirect) dependency, and it is more actively maintained, we drop the dependency on `py2-ipaddress` and use the `ipaddress` module instead.

This means we need to ensure we always give it unicode though, so some tests that directly instantiate `ip_network`s need to be fixed, and the functions for parsing IP range specifications need to ensure they always convert their input to unicode if necessary.