### PR TITLE
Pin down jsonschema to 2.6.0 in order to fix tests

### DIFF
--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -8,3 +8,7 @@ package-name = ftw.tokenauth
 # Pin down zc.buildout because of an issue with 2.11.1 where setuptools
 # loops trying to upgrade itself
 zc.buildout = 2.11.0
+
+# jsonschema >= 3.0.0a1 requires a version of six that is more recent than
+# the one currently pinned for Plone.
+jsonschema = 2.6.0


### PR DESCRIPTION
`jsonschema >= 3.0.0a1` requires a version of `six` that is more recent than the one currently pinned for Plone.

Fixes [current test failures](https://ci.4teamwork.ch/builds/178403/tasks/288985).