### PR TITLE
Fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,14 @@
 /.mr.developer.cfg
 /README.html
 /bin/
+/build/
 /buildout.cfg
 /coverage/
 /develop-eggs/
+/dist/
 /eggs/
+/include/
+/lib/
 /parts/
 /src/
 /var/

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -5,10 +5,6 @@ extends =
 package-name = ftw.tokenauth
 
 [versions]
-# Pin down zc.buildout because of an issue with 2.11.1 where setuptools
-# loops trying to upgrade itself
-zc.buildout = 2.11.0
-
 # jsonschema >= 3.0.0a1 requires a version of six that is more recent than
 # the one currently pinned for Plone.
 jsonschema = 2.6.0


### PR DESCRIPTION
Fix tests by no longer pinning down zc.buildout. Buildout was trying to update setuptools, which ended up in a recursion.

Also added gitignore entries for local virtualenvs.