### PR TITLE
Pin down PyJWT to 1.7.1 in order to fix tests.

### DIFF
--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -8,3 +8,5 @@ package-name = ftw.tokenauth
 # jsonschema >= 3.0.0a1 requires a version of six that is more recent than
 # the one currently pinned for Plone.
 jsonschema = 2.6.0
+# PyJWT 2.0.0 has dropped python 2 support.
+PyJWT = 1.7.1


### PR DESCRIPTION
PyJWT >= 2.0.0 has dropped python 2 support, we pin to the latest available compatible version for testing.

See https://pyjwt.readthedocs.io/en/stable/changelog.html#v2-0-0.

Jira: https://4teamwork.atlassian.net/browse/CA-1305