### PR TITLE
Require cryptography with python 2 support.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(name='ftw.tokenauth',
           'zope.schema',
           'Zope2',
           # Other dependencies
-          'cryptography',
+          'cryptography < 3.4',
           'ftw.profilehook',
           'ftw.upgrade',
           'ipaddress',


### PR DESCRIPTION
Cryptography has dropped support for python 2 in version 3.4: https://github.com/pyca/cryptography/blob/master/CHANGELOG.rst#34---2021-02-07. This package is python 2 only for the moment.

Jira: https://4teamwork.atlassian.net/browse/CA-1305