### PR TITLE
Properly extract authentication username

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Properly extract authentication username [elioschmutz]
 
 
 1.2.0 (2023-12-13)

--- a/ftw/tokenauth/pas/plugin.py
+++ b/ftw/tokenauth/pas/plugin.py
@@ -269,7 +269,7 @@ class TokenAuthenticationPlugin(BasePlugin):
 
             user_id = member.getId()
 
-        return user_id, user_id
+        return user_id, member.getUser().getUserName()
 
     security.declareProtected(ManagePortal, 'manage_updateConfig')
 

--- a/ftw/tokenauth/tests/test_oauth2_token_endpoint.py
+++ b/ftw/tokenauth/tests/test_oauth2_token_endpoint.py
@@ -6,6 +6,7 @@ from ftw.tokenauth.tests import FunctionalTestCase
 from plone import api
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
 import jwt
 import transaction
 
@@ -169,7 +170,7 @@ class TestOAuth2TokenEndpoint(FunctionalTestCase):
         token = browser.json['access_token']
         creds = {'access_token': token, 'extractor': 'token_auth'}
         self.assertEqual(
-            (TEST_USER_ID, TEST_USER_ID),
+            (TEST_USER_ID, TEST_USER_NAME),
             self.plugin.authenticateCredentials(creds))
 
     @browsing

--- a/ftw/tokenauth/tests/test_pas_plugin.py
+++ b/ftw/tokenauth/tests/test_pas_plugin.py
@@ -6,8 +6,10 @@ from ftw.testing import freeze
 from ftw.tokenauth.pas.storage import CredentialStorage
 from ftw.tokenauth.tests import FunctionalTestCase
 from plone import api
+from plone import api
 from plone.app.testing import login
 from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
 from zExceptions import Unauthorized
 import json
 
@@ -48,7 +50,7 @@ class TestTokenAuthPlugin(FunctionalTestCase):
             'access_token': create(Builder('access_token'))['token'],
         }
         self.assertEqual(
-            (TEST_USER_ID, TEST_USER_ID),
+            (TEST_USER_ID, TEST_USER_NAME),
             self.plugin.authenticateCredentials(creds))
 
     def test_authenticate_credentials_rejects_expired_token(self):
@@ -80,7 +82,7 @@ class TestTokenAuthPlugin(FunctionalTestCase):
         }
 
         self.assertEqual(
-            (TEST_USER_ID, TEST_USER_ID),
+            (TEST_USER_ID, TEST_USER_NAME),
             self.plugin.authenticateCredentials(creds))
 
     def test_authenticate_credentials_rejects_unknown_user(self):
@@ -107,7 +109,7 @@ class TestTokenAuthPlugin(FunctionalTestCase):
         }
 
         self.assertEqual(
-            ('jane', 'jane'),
+            ('jane', 'jane_username'),
             self.plugin.authenticateCredentials(creds))
 
     def test_authenticate_credentials_denies_unkown_client_ip(self):
@@ -147,7 +149,7 @@ class TestTokenAuthPlugin(FunctionalTestCase):
             'access_token': access_token['token'],
         }
         self.assertEqual(
-            (TEST_USER_ID, TEST_USER_ID),
+            (TEST_USER_ID, TEST_USER_NAME),
             self.plugin.authenticateCredentials(creds))
 
     def test_issuing_access_token_logs_key_usage(self):


### PR DESCRIPTION
This PR ensures that the username is correctly extracted and returned when the PAS plugin requests authentication credentials.

As defined by the [IAuthenticationPlugin interface](https://github.com/plone/Products.PluggableAuthService/blob/master/Products/PluggableAuthService/interfaces/plugins.py#L87), the authenticateCredentials method must return both the userid and the login name.

Currently, the ftw.tokenauth authentication plugin incorrectly returns the userid for both the userid and login name. This behavior deviates from the expected implementation and causes issues when trying to lookup a user through a user enumeration plugin by using the currently logged-in users username. For example, when using `plone.api.env.adopt_user`: https://github.com/plone/plone.api/blob/1.10.0/src/plone/api/env.py#L57

This PR resolves the issue by ensuring that the login name is properly extracted and returned, adhering to the interface's requirements.

Jira: [TI-1911](https://4teamwork.atlassian.net/browse/TI-1911)

